### PR TITLE
Expose arguments in CloudAzimuth 

### DIFF
--- a/R/annotation.R
+++ b/R/annotation.R
@@ -22,6 +22,7 @@
 #' @param process_obj Whether to process the object
 #' @param cutoff_abs Absolute cutoff for label filtering
 #' @param cutoff_frac Fractional cutoff for label filtering
+#' @param model_version Version of the model to use
 #' @return Annotated Seurat object
 #' @export
 ANNotate <- function(
@@ -43,6 +44,7 @@ ANNotate <- function(
   umap_seed = 42,
   spread = 1.0,
   verbose = TRUE,
+  model_version = "v0",
   init = "spectral",
   process_obj = TRUE,
   cutoff_abs = 5,
@@ -86,6 +88,7 @@ ANNotate <- function(
     umap_seed, 
     spread,
     verbose,
+    model_version,
     init
   )
   

--- a/R/api_interface.R
+++ b/R/api_interface.R
@@ -6,9 +6,14 @@
 #' @importFrom curl new_handle handle_setform curl_fetch_stream
 #' @importFrom jsonlite fromJSON
 #' @export
-listen_to_progress <- function(url, file_path) {
+listen_to_progress <- function(url, file_path, ...) {
   # Create a multipart form for the upload
-  form <- list(file = upload_file(file_path))
+  additional_args <- list(...)
+  additional_args <- lapply(additional_args, as.character)
+  form <- c(
+    list(file = upload_file(file_path)),
+    additional_args
+  )
   
   # Open a connection to the API using curl
   handle <- new_handle()

--- a/R/argument_parser.R
+++ b/R/argument_parser.R
@@ -148,6 +148,13 @@ parse_annotate_args <- function() {
   )
   
   parser$add_argument(
+    "--model_version",
+    default = "v0",
+    help = "Version of the model to use (default: 'v0')",
+    type = "character"
+  )
+  
+  parser$add_argument(
     "-i", "--init",
     default = "spectral",
     help = "Initialization method for UMAP (default: 'spectral')",
@@ -218,6 +225,7 @@ format_annotate_args <- function(args) {
     umap_seed = args$umap_seed,
     spread = args$spread,
     verbose = args$verbose,
+    model_version = args$model_version,
     init = args$init,
     process_obj = args$process_obj,
     cutoff_abs = args$cutoff_abs,

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -9,7 +9,7 @@
 #' @importFrom RCurl url.exists
 #' @export
 CloudAzimuth <- function(object = object, assay = 'RNA', ip = '34.222.135.233', 
-                         port = 5000) {
+                         port = 5000, ...) {
   message("Running Pan-Human Azimuth on the cloud!")
   
   layer_name <- 'data'
@@ -38,7 +38,7 @@ CloudAzimuth <- function(object = object, assay = 'RNA', ip = '34.222.135.233',
   saveRDS(object = srt, file = tmp_input)
   api_base_url <- paste0('http://', ip, ":", port)
   
-  process_rds_file(api_base_url, tmp_input)
+  process_rds_file(api_base_url, tmp_input, ...)
   srt <- readRDS(file = tmp_output)
   
   # Copy reductions
@@ -65,10 +65,10 @@ CloudAzimuth <- function(object = object, assay = 'RNA', ip = '34.222.135.233',
 #' @param input_file Path to input RDS file
 #' @return NULL
 #' @importFrom httr POST GET upload_file content status_code
-process_rds_file <- function(api_base_url, file_path) {
+process_rds_file <- function(api_base_url, file_path, ...) {
   progress_url <- paste0(api_base_url, "/process_rds")
   cat("Uploading file and listening for updates...\n")
-  listen_to_progress(progress_url, file_path)
+  listen_to_progress(progress_url, file_path, ...)
   output_file_name <- gsub("\\.rds$", "_ANN.rds", basename(file_path))
   download_url <- paste0(api_base_url, "/download_output?output_file=/tmp/", 
                          output_file_name)
@@ -76,3 +76,4 @@ process_rds_file <- function(api_base_url, file_path) {
   cat("Downloading the output file...\n")
   download_output(download_url, save_path)
 } 
+


### PR DESCRIPTION
This PR enables passing in any user inputs for all ANNotate arguments using the long-form flag. Coupled with https://github.com/satijalab/CloudAzimuthServer/pull/1

Example:

`obj <- CloudAzimuth(obj,ip='10.4.120.13',model_version='v1',refine_labels=FALSE,verbose=TRUE) `